### PR TITLE
[FEAT]: FIREBASE 키 파일 직접 지정 후 실행하도록 변경

### DIFF
--- a/src/main/java/ddd/darayo/festival/FestivalApplication.java
+++ b/src/main/java/ddd/darayo/festival/FestivalApplication.java
@@ -3,27 +3,58 @@ package ddd.darayo.festival;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.FirebaseOptions;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
+import java.io.FileInputStream;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
+@Slf4j
 @SpringBootApplication
 @EnableScheduling
 public class FestivalApplication {
 
-    public static void main(String[] args) {
-        SpringApplication.run(FestivalApplication.class, args);
-        try {
-            FirebaseOptions options = FirebaseOptions.builder()
-                    .setCredentials(GoogleCredentials.getApplicationDefault())
-                    .build();
+    @Value("${firebase.service-account-key}")
+    private static String firebaseServiceAccountKeyPath;
 
-            FirebaseApp.initializeApp(options);
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
+    public static void main(String[] args) {
+        ConfigurableApplicationContext context = SpringApplication.run(FestivalApplication.class, args);
+        
+        // Firebase 초기화를 애플리케이션 시작 후에 실행
+        String keyPath = context.getEnvironment().getProperty("firebase.service-account-key");
+        initializeFirebase(keyPath);
     }
 
+    private static void initializeFirebase(String keyPath) {
+        try {
+            Path serviceAccountKeyPath = Paths.get(keyPath);
+            
+            if (!Files.exists(serviceAccountKeyPath)) {
+                log.warn("Firebase 서비스 계정 키 파일이 존재하지 않습니다: {}", keyPath);
+                log.warn("Firebase 기능이 비활성화됩니다.");
+                return;
+            }
+            
+            log.info("Firebase 서비스 계정 키 파일 로드 중: {}", keyPath);
+            
+            try (FileInputStream serviceAccount = new FileInputStream(serviceAccountKeyPath.toFile())) {
+                FirebaseOptions options = FirebaseOptions.builder()
+                        .setCredentials(GoogleCredentials.fromStream(serviceAccount))
+                        .build();
+
+                FirebaseApp.initializeApp(options);
+                log.info("Firebase 초기화가 성공적으로 완료되었습니다.");
+            }
+        } catch (IOException e) {
+            log.error("Firebase 초기화 중 오류 발생: {}", e.getMessage(), e);
+            throw new RuntimeException("Firebase 초기화 실패", e);
+        }
+    }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -20,6 +20,10 @@ spring:
 auth:
   password: ${ADMIN_PASSWORD}
 
+# Firebase 설정
+firebase:
+  service-account-key: ${FIREBASE_SERVICE_ACCOUNT_KEY_PATH}
+
 springdoc:
   use-fqn: true
 

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -7,6 +7,10 @@ spring:
 auth:
   password: test
 
+# Firebase 설정 (테스트 환경에서는 비활성화)
+firebase:
+  service-account-key: ./test-firebase-key.json
+
 jwt:
   secret-key: test-secret-key-for-jwt-token-signing-at-least-32-bytes
   expire-length: 86400000


### PR DESCRIPTION
### **User description**
## 📌 PR 설명
<!-- 변경 목적, 동기, 관련된 컨텍스트(예: 크롤러 수정, API 명세 변경 등)를 간단히 설명해주세요 -->
- 권한 버그 수정 목적

## 🛠️ 변경 유형
- [x] 버그 수정
- [ ] 신규 기능 추가
- [ ] 기존 기능 개선 / 리팩토링
- [ ] 문서 수정
- [ ] 기타 (아래에 작성)

## 🖼️ 스크린샷 또는 로그 (필요 시)
<!-- ex: API 응답 예시, 콘솔 로그, 크롤러 결과 캡처 등 -->

## 💬 기타 참고 사항
<!-- 리뷰어가 이해하는 데 도움이 되는 설명이나 고민했던 사항이 있다면 자유롭게 작성해주세요 -->


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Firebase 초기화 로직 분리 및 개선

- 서비스 계정 키 파일 경로 직접 지정

- `application.yml`에 Firebase 설정 추가

- 키 파일 유효성 검사 및 오류 처리 강화


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>FestivalApplication.java</strong><dd><code>Firebase 초기화 로직 개선 및 키 파일 직접 로드</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/ddd/darayo/festival/FestivalApplication.java

<li>Firebase 초기화 로직을 별도의 <code>initializeFirebase</code> 메서드로 분리했습니다.<br> <li> 서비스 계정 키를 <code>application.yml</code>에서 지정된 경로를 통해 직접 로드하도록 변경했습니다.<br> <li> 키 파일의 존재 여부를 확인하고, 없을 경우 경고 로그를 남기며 Firebase 기능을 비활성화합니다.<br> <li> 초기화 과정에서 발생하는 오류에 대한 로깅 및 예외 처리를 강화했습니다.


</details>


  </td>
  <td><a href="https://github.com/DDD-Community/DDD-12-Darayo-Backend/pull/26/files#diff-80781bbddad4f0b59cf04106dbf5b37feeb7f2840aed563caaef16064afe78b5">+38/-7</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>application.yml</strong><dd><code>Firebase 서비스 계정 키 경로 설정 추가</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/resources/application.yml

<li><code>firebase</code> 섹션을 추가하여 Firebase 관련 설정을 정의했습니다.<br> <li> <code>service-account-key</code> 속성을 <code>FIREBASE_SERVICE_ACCOUNT_KEY_PATH</code> 환경 변수에서 <br>가져오도록 설정했습니다.


</details>


  </td>
  <td><a href="https://github.com/DDD-Community/DDD-12-Darayo-Backend/pull/26/files#diff-7bc26be01d3e7c9c566f2a28dc1b5cd87dbdd5cb619184f46eb2bf223bf7825d">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>application.yml</strong><dd><code>테스트 환경 Firebase 설정 추가</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/test/resources/application.yml

<li>테스트 환경을 위한 <code>firebase</code> 섹션을 추가했습니다.<br> <li> <code>service-account-key</code> 속성에 테스트용 더미 경로를 지정했습니다.


</details>


  </td>
  <td><a href="https://github.com/DDD-Community/DDD-12-Darayo-Backend/pull/26/files#diff-9505534937cc795b823f36b038529b4a0fc1cc060b9c14df770504a187e6ef69">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>