### PR TITLE
Fix/#28 bug 토큰 만료 및 nullexception 오류

### DIFF
--- a/src/main/java/ddd/darayo/festival/domain/exception/constant/AuthError.java
+++ b/src/main/java/ddd/darayo/festival/domain/exception/constant/AuthError.java
@@ -1,0 +1,23 @@
+package ddd.darayo.festival.domain.exception.constant;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public enum AuthError implements ErrorInfo{
+    AUTH_FAIL("9000","인증에 실패했습니다."),
+    ;
+
+    private final String code;
+    private final String description;
+
+    @Override
+    public String getDesc() {
+        return description;
+    }
+
+    @Override
+    public String getCode() {
+        return code;
+    }
+}

--- a/src/main/java/ddd/darayo/festival/infra/web/AuthInterceptor.java
+++ b/src/main/java/ddd/darayo/festival/infra/web/AuthInterceptor.java
@@ -8,13 +8,14 @@ import io.jsonwebtoken.JwtException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerInterceptor;
 
-import static ddd.darayo.festival.domain.exception.constant.ArtistError.ARTIST_NOT_EXISTS;
 import static ddd.darayo.festival.domain.exception.constant.UserError.NOT_FOUND_USER;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class AuthInterceptor implements HandlerInterceptor {
@@ -44,6 +45,7 @@ public class AuthInterceptor implements HandlerInterceptor {
             
             request.setAttribute("userId", userId);
         } catch (JwtException e) {
+            log.info("Invalid JWT token: {}", e.getMessage());
             throw new APIException(AuthError.AUTH_FAIL, HttpStatus.BAD_REQUEST);
         }
 

--- a/src/main/java/ddd/darayo/festival/infra/web/AuthInterceptor.java
+++ b/src/main/java/ddd/darayo/festival/infra/web/AuthInterceptor.java
@@ -1,5 +1,6 @@
 package ddd.darayo.festival.infra.web;
 
+import ddd.darayo.festival.domain.exception.constant.AuthError;
 import ddd.darayo.festival.domain.repository.UserRepository;
 import ddd.darayo.festival.infra.jwt.JwtService;
 import ddd.darayo.festival.presentation.common.exception.APIException;
@@ -43,7 +44,7 @@ public class AuthInterceptor implements HandlerInterceptor {
             
             request.setAttribute("userId", userId);
         } catch (JwtException e) {
-            throw APIException.from(e, HttpStatus.BAD_REQUEST);
+            throw new APIException(AuthError.AUTH_FAIL, HttpStatus.BAD_REQUEST);
         }
 
         return true;

--- a/src/main/java/ddd/darayo/festival/presentation/artist/ArtistAdminController.java
+++ b/src/main/java/ddd/darayo/festival/presentation/artist/ArtistAdminController.java
@@ -37,7 +37,7 @@ public class ArtistAdminController {
         try {
             artistManagement.createArtistAlias(req);
         } catch (DomainException e) {
-            throw APIException.from(e, HttpStatus.NOT_FOUND);
+            throw new APIException(e, HttpStatus.NOT_FOUND);
         }
         return ResponseEntity.ok().build();
     }
@@ -50,7 +50,7 @@ public class ArtistAdminController {
             artistManagement.editArtist(req, artistId);
             return new ResponseEntity<>(HttpStatus.OK);
         } catch (DomainException e) {
-            throw APIException.from(e, HttpStatus.NOT_FOUND);
+            throw new APIException(e, HttpStatus.NOT_FOUND);
         }
     }
 
@@ -62,7 +62,7 @@ public class ArtistAdminController {
             artistManagement.editArtistAlias(req, aliasId);
             return new ResponseEntity<>(HttpStatus.OK);
         } catch (DomainException e) {
-            throw APIException.from(e, HttpStatus.NOT_FOUND);
+            throw new APIException(e, HttpStatus.NOT_FOUND);
         }
     }
 
@@ -74,7 +74,7 @@ public class ArtistAdminController {
             artistManagement.deleteArtistAlias(aliasId);
             return new ResponseEntity<>(HttpStatus.OK);
         } catch (DomainException e) {
-            throw APIException.from(e, HttpStatus.NOT_FOUND);
+            throw new APIException(e, HttpStatus.NOT_FOUND);
         }
     }
 

--- a/src/main/java/ddd/darayo/festival/presentation/common/exception/APIException.java
+++ b/src/main/java/ddd/darayo/festival/presentation/common/exception/APIException.java
@@ -5,19 +5,18 @@ import ddd.darayo.festival.domain.exception.constant.ErrorInfo;
 import org.springframework.http.HttpStatus;
 
 public class APIException extends RuntimeException {
-    public ErrorInfo error;
+    public final ErrorInfo error;
     public HttpStatus status;
 
-    public static APIException from(RuntimeException ex, HttpStatus status) {
-        return new APIException(ex.getMessage(), status);
+    public APIException(ErrorInfo errorInfo, HttpStatus status) {
+        super(errorInfo.getMessage());
+        this.error = errorInfo;
+        this.status = status;
     }
 
-    public static APIException of(Exception ex, HttpStatus status) {
-        return new APIException(ex.getMessage(), status);
-    }
-
-    private APIException(String message, HttpStatus status) {
-        super(message);
+    public APIException(DomainException exception, HttpStatus status) {
+        super(exception.getMessage());
+        this.error = exception.error;
         this.status = status;
     }
 }

--- a/src/main/java/ddd/darayo/festival/presentation/performance/PerformanceController.java
+++ b/src/main/java/ddd/darayo/festival/presentation/performance/PerformanceController.java
@@ -50,7 +50,7 @@ public class PerformanceController {
             return ResponseEntity.ok(BaseResponse.success());
         } catch (DomainException e) {
             log.warn("공연 알림 설정 실패 - 사용자: {}, 공연: {}, 오류: {}", userId, festivalId, e.getMessage());
-            throw APIException.from(e, HttpStatus.BAD_REQUEST);
+            throw new APIException(e, HttpStatus.NOT_FOUND);
         }
     }
 
@@ -65,7 +65,7 @@ public class PerformanceController {
             return ResponseEntity.ok(BaseResponse.success());
         } catch (DomainException e) {
             log.warn("공연 알림 해제 실패 - 사용자: {}, 공연: {}, 오류: {}", userId, festivalId, e.getMessage());
-            throw APIException.from(e, HttpStatus.NOT_FOUND);
+            throw new APIException(e, HttpStatus.NOT_FOUND);
         }
     }
 }


### PR DESCRIPTION
### **User description**
## 📌 PR 설명
<!-- 변경 목적, 동기, 관련된 컨텍스트(예: 크롤러 수정, API 명세 변경 등)를 간단히 설명해주세요 -->
APIException에 errorCode를 담지 않았는데 이를 참조하여 로깅하는 과정에서 nullpointer exception이 발생하여 이를 수정했습니다.

관련 이슈: #28 

## 🛠️ 변경 유형
- [x] 버그 수정
- [ ] 신규 기능 추가
- [ ] 기존 기능 개선 / 리팩토링
- [ ] 문서 수정
- [ ] 기타 (아래에 작성)

## 🖼️ 스크린샷 또는 로그 (필요 시)
<!-- ex: API 응답 예시, 콘솔 로그, 크롤러 결과 캡처 등 -->
### 로그 수정
<img width="1030" height="64" alt="image" src="https://github.com/user-attachments/assets/12b186cd-68ec-43e5-a6e0-8681025960f6" />

### 응답 수정. http status 400, 응답 코드 9000
<img width="473" height="283" alt="image" src="https://github.com/user-attachments/assets/6a1e794a-397f-450c-8129-e6c419e0f2d1" />


## 💬 기타 참고 사항
<!-- 리뷰어가 이해하는 데 도움이 되는 설명이나 고민했던 사항이 있다면 자유롭게 작성해주세요 -->


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- APIException에 ErrorInfo 포함 강제

- 인증 실패 시 AuthError 코드 사용

- JWT 예외 발생 시 로깅 추가

- 컨트롤러에서 APIException 사용 통일


___

### **Changes diagram**

```mermaid
flowchart LR
  A[AuthInterceptor] --> B{APIException 발생};
  B --> C[APIException];
  C -- "ErrorInfo 강제 포함" --> D[ErrorInfo];
  D <-- E[AuthError];
  F[ArtistAdminController] --> C;
  G[PerformanceController] --> C;
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AuthError.java</strong><dd><code>인증 오류를 위한 새로운 AuthError enum 정의</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/ddd/darayo/festival/domain/exception/constant/AuthError.java

<li>새로운 <code>AuthError</code> enum을 정의하여 인증 실패에 대한 특정 오류 코드(<code>9000</code>)와 설명을 추가했습니다.<br> <li> <code>ErrorInfo</code> 인터페이스를 구현하여 오류 정보 표준화를 따릅니다.


</details>


  </td>
  <td><a href="https://github.com/DDD-Community/DDD-12-Darayo-Backend/pull/30/files#diff-27e8ab5876f9db278f4e6c6f7310d9a4e8f23e4d299e91b5e9172a6ef929cd48">+23/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AuthInterceptor.java</strong><dd><code>JWT 예외 로깅 및 특정 인증 오류 처리</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/ddd/darayo/festival/infra/web/AuthInterceptor.java

<li><code>JwtException</code> 발생 시 로그를 추가하여 디버깅 정보를 제공합니다.<br> <li> <code>APIException</code> 생성자를 <code>AuthError.AUTH_FAIL</code>과 함께 사용하여 인증 실패 시 특정 오류 코드를 반환하도록 <br>변경했습니다.


</details>


  </td>
  <td><a href="https://github.com/DDD-Community/DDD-12-Darayo-Backend/pull/30/files#diff-5fea2de353433904d5ec5bc4535083cd80d4e2efd273b91029b0175c620d79e8">+5/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>APIException.java</strong><dd><code>APIException 생성자 리팩토링 및 ErrorInfo 포함 강제</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/ddd/darayo/festival/presentation/common/exception/APIException.java

<li><code>APIException</code> 클래스에서 <code>ErrorInfo</code> 필드를 <code>final</code>로 선언했습니다.<br> <li> 기존의 정적 팩토리 메서드 <code>from</code>과 <code>of</code>를 제거했습니다.<br> <li> <code>ErrorInfo</code> 또는 <code>DomainException</code>을 직접 받아 <code>APIException</code>을 생성하는 두 가지 새로운 생성자를 <br>추가하여 <code>ErrorInfo</code>가 항상 포함되도록 강제했습니다.


</details>


  </td>
  <td><a href="https://github.com/DDD-Community/DDD-12-Darayo-Backend/pull/30/files#diff-43902fe6ebaaa85de8a63a60f4463aa3a1271f8953d224ba17f2cbd1ac4e4f56">+8/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Refactoring</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ArtistAdminController.java</strong><dd><code>ArtistAdminController의 APIException 생성자 업데이트</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/ddd/darayo/festival/presentation/artist/ArtistAdminController.java

<li><code>DomainException</code>을 처리하는 <code>catch</code> 블록에서 <code>APIException.from</code> 대신 새로운 <br><code>APIException(e, HttpStatus)</code> 생성자를 사용하도록 업데이트했습니다.<br> <li> 이는 <code>APIException</code>이 항상 <code>ErrorInfo</code>를 포함하도록 보장합니다.


</details>


  </td>
  <td><a href="https://github.com/DDD-Community/DDD-12-Darayo-Backend/pull/30/files#diff-45bcb12731067e1335cf2c8cd2f0c2376bbc26bebbd598180d5e547ec65a6869">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>PerformanceController.java</strong><dd><code>PerformanceController의 APIException 생성자 업데이트</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/ddd/darayo/festival/presentation/performance/PerformanceController.java

<li><code>DomainException</code>을 처리하는 <code>catch</code> 블록에서 <code>APIException.from</code> 대신 새로운 <br><code>APIException(e, HttpStatus)</code> 생성자를 사용하도록 업데이트했습니다.<br> <li> 이는 <code>APIException</code>이 항상 <code>ErrorInfo</code>를 포함하도록 보장합니다.


</details>


  </td>
  <td><a href="https://github.com/DDD-Community/DDD-12-Darayo-Backend/pull/30/files#diff-304039c2db74cee003393fa42e090095e30be83fdd4e3503580b66d5d15edb02">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>