### PR TITLE
알림 토큰 등록 시 isValid가 null 인 오류 수정

### DIFF
--- a/src/main/java/ddd/darayo/festival/domain/entity/UserAlarmToken.java
+++ b/src/main/java/ddd/darayo/festival/domain/entity/UserAlarmToken.java
@@ -46,6 +46,7 @@ public class UserAlarmToken {
     public UserAlarmToken(Long userId, String alarmToken, LocalDateTime createdAt) {
         this.userId = userId;
         this.alarmToken = alarmToken;
+        this.isValid = true;
         this.updatedAt = createdAt;
     }
 }

--- a/src/main/java/ddd/darayo/festival/domain/service/UserService.java
+++ b/src/main/java/ddd/darayo/festival/domain/service/UserService.java
@@ -36,4 +36,11 @@ public class UserService {
 
         user.updateAlarmPermission(permissionEnabled);
     }
+
+    public boolean getPushPermission(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow();
+
+        return user.getIsAlarmAllowed();
+    }
 }

--- a/src/main/java/ddd/darayo/festival/presentation/user/UserController.java
+++ b/src/main/java/ddd/darayo/festival/presentation/user/UserController.java
@@ -16,7 +16,6 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/v1/users")
 @RequiredArgsConstructor
 public class UserController {
-    private final UserRepository userRepository;
     private final UserService userService;
 
     @PostMapping("/login")
@@ -37,9 +36,8 @@ public class UserController {
     public ResponseEntity<BaseResponse<Boolean>> getPushPermission(
             @RequestAttribute("userId") Long userId
     ) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(UserError.NOT_FOUND_USER::toException);
-        return ResponseEntity.ok(BaseResponse.success(user.getIsAlarmAllowed()));
+        boolean isPushAlarmed = userService.getPushPermission(userId);
+        return ResponseEntity.ok(BaseResponse.success(isPushAlarmed));
     }
 }
 


### PR DESCRIPTION
### **User description**
## 📌 PR 설명
<!-- 변경 목적, 동기, 관련된 컨텍스트(예: 크롤러 수정, API 명세 변경 등)를 간단히 설명해주세요 -->

관련 이슈: [FSTB-96](https://darayos2.atlassian.net/browse/FSTB-96)

## 🛠️ 변경 유형
- [x] 버그 수정
- [ ] 신규 기능 추가
- [ ] 기존 기능 개선 / 리팩토링
- [ ] 문서 수정
- [ ] 기타 (아래에 작성)

## 🖼️ 스크린샷 또는 로그 (필요 시)
<!-- ex: API 응답 예시, 콘솔 로그, 크롤러 결과 캡처 등 -->

## 💬 기타 참고 사항
<!-- 리뷰어가 이해하는 데 도움이 되는 설명이나 고민했던 사항이 있다면 자유롭게 작성해주세요 -->


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- `UserAlarmToken` 생성 시 `isValid` 기본값 설정.

- `UserService`에 푸시 알림 권한 조회 로직 추가.

- `UserController`에서 `UserService`를 통해 권한 조회.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>UserAlarmToken.java</strong><dd><code>`UserAlarmToken` 생성자 `isValid` 필드 초기화</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/ddd/darayo/festival/domain/entity/UserAlarmToken.java

<li><code>UserAlarmToken</code> 생성자에 <code>this.isValid = true;</code> 코드를 추가하여 <code>isValid</code> 필드가 기본적으로 <br><code>true</code>로 초기화되도록 수정했습니다.<br> <li> 이를 통해 알림 토큰 등록 시 <code>isValid</code> 필드가 <code>null</code>이 되는 오류를 방지합니다.


</details>


  </td>
  <td><a href="https://github.com/DDD-Community/DDD-12-Darayo-Backend/pull/46/files#diff-7c28df02ddb936cd6f31aaebadbd0f422cac4c01d16daaec5db94a3cf724626f">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>UserService.java</strong><dd><code>`UserService`에 푸시 알림 권한 조회 메서드 추가</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/ddd/darayo/festival/domain/service/UserService.java

<li>사용자 푸시 알림 권한을 조회하는 새로운 공용 메서드 <code>getPushPermission(Long userId)</code>를 추가했습니다.<br> <li> 이 메서드는 <code>UserRepository</code>를 통해 사용자를 찾고 해당 사용자의 <code>isAlarmAllowed</code> 값을 반환합니다.


</details>


  </td>
  <td><a href="https://github.com/DDD-Community/DDD-12-Darayo-Backend/pull/46/files#diff-0ac7abf427ce0ad9d07add71e000dc4789758c601e5608135c7f8766d24d9005">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Refactoring</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>UserController.java</strong><dd><code>`UserController` 푸시 알림 조회 로직 개선</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/ddd/darayo/festival/presentation/user/UserController.java

<li><code>UserRepository</code>에 대한 직접적인 의존성을 제거했습니다.<br> <li> <code>getPushPermission</code> 엔드포인트가 <code>UserService</code>의 <code>getPushPermission</code> 메서드를 호출하도록 <br>변경하여 비즈니스 로직을 서비스 계층으로 위임했습니다.


</details>


  </td>
  <td><a href="https://github.com/DDD-Community/DDD-12-Darayo-Backend/pull/46/files#diff-f9d01bac72001d539dfc588b6afdb524c71354502d669394b970fafe8a149157">+2/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

[FSTB-96]: https://darayos2.atlassian.net/browse/FSTB-96?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ