### PR TITLE
feat/앱 조회 시 아티스트 image url 추가

### DIFF
--- a/src/main/java/ddd/darayo/festival/domain/service/mapper/TimetableMapper.java
+++ b/src/main/java/ddd/darayo/festival/domain/service/mapper/TimetableMapper.java
@@ -40,6 +40,7 @@ public interface TimetableMapper {
 
         @Mapping(target = "artistId", source = "artist.id")
         @Mapping(target = "artistDisplayName", source = "artist.displayName")
+        @Mapping(target = "artistImageUrl", source = "artist.imageUrl")
         @Mapping(target = "performanceDate", source = "timetable.performanceDate")
         UserGetPerformanceInfo.ArtistDetailRes toArtistDetail(TimetableArtist timetableArtist);
 

--- a/src/main/java/ddd/darayo/festival/infra/applemusic/AppleMusicTokenProvider.java
+++ b/src/main/java/ddd/darayo/festival/infra/applemusic/AppleMusicTokenProvider.java
@@ -33,12 +33,11 @@ public class AppleMusicTokenProvider {
     public void init() throws Exception {
         try{
             generateAndCacheToken(); // 앱 시작 시 미리 생성
+            log.info("[AppleMusic] - 토큰 생성 완료");
         } catch (Exception e) {
             log.warn("[AppleMusic] - Apple Music Developer Token 초기화 실패.");
             log.warn("[AppleMusic] - 실패 원인 : ", e);
         }
-
-        log.info("[AppleMusic] - 토큰 생성 완료");
     }
 
     public synchronized String getDeveloperToken() throws Exception {

--- a/src/main/java/ddd/darayo/festival/presentation/performance/exchanges/UserGetPerformanceInfo.java
+++ b/src/main/java/ddd/darayo/festival/presentation/performance/exchanges/UserGetPerformanceInfo.java
@@ -35,6 +35,7 @@ public record UserGetPerformanceInfo(
     public record ArtistDetailRes(
             Long artistId,
             String artistDisplayName,
+            String artistImageUrl,
             LocalDate performanceDate
     ) { }
 


### PR DESCRIPTION
### **User description**
## 📌 PR 설명
<!-- 변경 목적, 동기, 관련된 컨텍스트(예: 크롤러 수정, API 명세 변경 등)를 간단히 설명해주세요 -->

관련 이슈: #

## 🛠️ 변경 유형
- [ ] 버그 수정
- [x] 신규 기능 추가
- [ ] 기존 기능 개선 / 리팩토링
- [ ] 문서 수정
- [ ] 기타 (아래에 작성)

## 🖼️ 스크린샷 또는 로그 (필요 시)
<!-- ex: API 응답 예시, 콘솔 로그, 크롤러 결과 캡처 등 -->

## 💬 기타 참고 사항
<!-- 리뷰어가 이해하는 데 도움이 되는 설명이나 고민했던 사항이 있다면 자유롭게 작성해주세요 -->


___

### **PR Type**
Enhancement


___

### **Description**
- 아티스트 상세 정보에 이미지 URL 추가

- API 응답 DTO에 `artistImageUrl` 필드 반영

- 매퍼에서 아티스트 이미지 URL 매핑 처리

- Apple Music 토큰 생성 로그 위치 조정


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>TimetableMapper.java</strong><dd><code>아티스트 이미지 URL 매핑 로직 추가</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/ddd/darayo/festival/domain/service/mapper/TimetableMapper.java

<li><code>TimetableDetailMapper</code> 인터페이스의 <code>toArtistDetail</code> 메서드에 <code>@Mapping(target = </code><br><code>"artistImageUrl", source = "artist.imageUrl")</code>을 추가했습니다.<br> <li> 이를 통해 아티스트 이미지 URL이 응답에 포함되도록 매핑 로직을 확장했습니다.


</details>


  </td>
  <td><a href="https://github.com/DDD-Community/DDD-12-Darayo-Backend/pull/59/files#diff-95b86ceb20a40e96ae0be93ad2046042a515cc624784296fd5484b75769b732d">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>UserGetPerformanceInfo.java</strong><dd><code>아티스트 상세 응답 DTO에 이미지 URL 필드 추가</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/ddd/darayo/festival/presentation/performance/exchanges/UserGetPerformanceInfo.java

<li><code>UserGetPerformanceInfo.ArtistDetailRes</code> 레코드에 <code>artistImageUrl</code> 필드(String <br>타입)를 추가했습니다.<br> <li> 이 필드는 공연 아티스트 상세 정보 응답에 아티스트의 이미지 URL을 포함하기 위해 사용됩니다.


</details>


  </td>
  <td><a href="https://github.com/DDD-Community/DDD-12-Darayo-Backend/pull/59/files#diff-fb67730334c8e21babec73b959ed6220dd6c638737ef92d79cec07a2e51b58ef">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Miscellaneous</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AppleMusicTokenProvider.java</strong><dd><code>Apple Music 토큰 생성 로그 위치 조정</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/ddd/darayo/festival/infra/applemusic/AppleMusicTokenProvider.java

<li><code>AppleMusicTokenProvider</code>의 <code>init()</code> 메서드 내에서 토큰 생성 완료 <br>로그(<code>log.info("[AppleMusic] - 토큰 생성 완료");</code>)의 위치를 변경했습니다.<br> <li> <code>try-catch</code> 블록의 <code>try</code> 블록 내부에서 블록 외부로 이동하여, 예외 발생 여부와 관계없이 초기화 시도 후 로그가 <br>출력되도록 했습니다.


</details>


  </td>
  <td><a href="https://github.com/DDD-Community/DDD-12-Darayo-Backend/pull/59/files#diff-20e1709ee5fb97b8cde3d159130348809622c339a91fcf47787ecab4ae6caf06">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>